### PR TITLE
Added solving mode to the pruning table file name

### DIFF
--- a/src/prun.cpp
+++ b/src/prun.cpp
@@ -5,8 +5,20 @@
 #include <cstring>
 
 namespace prun {
+  const std::string SAVE = "twophase"
+  #ifdef QT
+    "_QT"
+  #else
+    "_HT"
+  #endif
+  #ifdef AX
+    "_AX"
+  #endif
+  #ifdef F5
+    "_F5"
+  #endif
+  ".tbl";
 
-  const std::string SAVE = "twophase.tbl";
   const int EMPTY = 0xff;
 
   #ifdef AX


### PR DESCRIPTION
The different solving modes require different pruning tables. When switching back and forth between the solving modes, one either had to delete and recompute the twophase.tbl file or keep copies for the different solving modes and rename them as needed.

This pull request changes the file name depending on the defines for the solving modes. That way one can quickly switch back and forth and the solver uses the correct one automatically.