### PR TITLE
Fixes reading from uninitialized arrays

### DIFF
--- a/src/move.cpp
+++ b/src/move.cpp
@@ -89,8 +89,8 @@ namespace move {
 
     cubie::cube cubes1[45];
     int inv1[45];
-    mask next1[45];
-    mask qt_skip1[45];
+    mask next1[45] = {0};
+    mask qt_skip1[45] = {0};
 
     std::string fnames[] = {"U", "D", "R", "L", "F", "B"};
     std::string pnames[] = {"", "2", "'"};


### PR DESCRIPTION
There were two uninitialized arrays of masks from which uninitialized values were read from. I've initialized these with 0 because it seems reasonable.
With this change, the solver produces the same output on macOS as on Ubuntu and it is just as fast :)